### PR TITLE
Add justify-self and justify-items grid properties

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1461,7 +1461,7 @@
             | grid|grid-area|grid-auto-columns|grid-auto-flow|grid-auto-rows|grid-column|grid-column-end|grid-column-gap
             | grid-column-start|grid-gap|grid-row|grid-row-end|grid-row-gap|grid-row-start|grid-template|grid-template-areas
             | grid-template-columns|grid-template-rows|height|hyphens|image-orientation|image-rendering|image-resolution
-            | ime-mode|inline-size|isolation|justify-content|left|letter-spacing|line-break|line-height|list-style
+            | ime-mode|inline-size|isolation|justify-self|justify-items|justify-content|left|letter-spacing|line-break|line-height|list-style
             | list-style-image|list-style-position|list-style-type|margin|margin-block-end|margin-block-start|margin-bottom
             | margin-inline-end|margin-inline-start|margin-left|margin-right|margin-top|mask|mask-clip|mask-composite
             | mask-image|mask-mode|mask-origin|mask-position|mask-repeat|mask-size|mask-type|max-block-size|max-height


### PR DESCRIPTION
Does this fork used in VS Code?

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
Add `justify-self` and `justify-items`
https://www.w3.org/TR/css-grid-1/#row-align
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Benefits

Syntax highlighting of this properties.

### Possible Drawbacks

None.