### PR TITLE
Add generic-name values of the font-family property

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1461,7 +1461,7 @@
         'name': 'support.constant.vendored.property-value.css'
       }
       {
-        'match': '(?<![\\w-])(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|monospace)(?![\\w-])'
+        'match': '(?<![\\w-])(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|cursive|fantasy|monospace)(?![\\w-])'
         'name': 'support.constant.font-name.css'
       }
     ]


### PR DESCRIPTION
Hi, @octref 
Please add these two [generic font][] families: 'cursive' and 'fantasy'. Visual Studio Code supports the code completion but without highlighting. Thanks!

[generic font]: https://www.w3.org/TR/css-fonts-3/#generic-font-families
