### PR TITLE
Fix downstream grammar issue

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -2047,7 +2047,7 @@
         | mrow|ms|mscarries|mscarry|msgroup|msline|mspace|msqrt|msrow|mstack|mstyle|msub|msubsup
         | msup|mtable|mtd|mtext|mtr|munder|munderover|semantics
       )
-      (?=[+~>\\s,.\\#|){:\\[]|/\\*|$)
+      (?=[+~>\\s,.\\#|){\\[]|:[^//s]|/\\*|$)
     '''
     'name': 'entity.name.tag.css'
   'unicode-range':


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

By saying a tag name can't have a space after the `:`, it fixes an issue in SASS where the words `content`, `cursor`, `filter`, `font`, and `mask` are marked as tag names.

### Alternate Designs

Attempts have been made to solve this in atom/language-sass, to no avail. This is the solution Atom used to fix it in their language.

### Benefits

SASS will no longer confuse these valid property names with tag names.

### Possible Drawbacks

This won't highlight properly if someone writes `cursor:default;` without using a space after the colon. At best, those people suffer the same downstream syntax highlighting we've all suffered with the last number of years. At worst, anyone who writes their CSS like that deserves to be locked up.

### Applicable Issues
atom/language-sass#226
